### PR TITLE
fix: type export error, bump versions

### DIFF
--- a/example-app/src/app/page.tsx
+++ b/example-app/src/app/page.tsx
@@ -1,57 +1,62 @@
 import Image from 'next/image'
 import CardElementsJs from './components/CardElements/CardElementsJs'
 import CardElementsReact from './components/CardElements/CardElementsReact'
+import Script from 'next/script'
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <div className="relative z-[-1] flex place-items-center before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px] before:lg:h-[360px]">
-        <Image
-          className="relative dark:drop-shadow-[0_0_0.3rem_#ffffff70] dark:invert"
-          src="/logo.svg"
-          alt="Next.js Logo"
-          width={300}
-          height={37}
-          priority
-        />
-      </div>
+    <>
+      <Script src="https://js.credova.com/v1.1.1" />
+      <Script src="https://js.basistheory.com/" />
+      <main className="flex min-h-screen flex-col items-center justify-between p-24">
+        <div className="relative z-[-1] flex place-items-center before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px] before:lg:h-[360px]">
+          <Image
+            className="relative dark:drop-shadow-[0_0_0.3rem_#ffffff70] dark:invert"
+            src="/logo.svg"
+            alt="Next.js Logo"
+            width={300}
+            height={37}
+            priority
+          />
+        </div>
 
-      <div className="grid lg:grid-cols-2 gap-8 w-full max-w-4xl">
-        <CardElementsJs />
-        <CardElementsReact />
-      </div>
+        <div className="grid lg:grid-cols-2 gap-8 w-full max-w-4xl">
+          <CardElementsJs />
+          <CardElementsReact />
+        </div>
 
-      <div className="mb-32 flex justify-center text-center lg:mb-0 lg:w-full lg:max-w-5xl lg:text-left">
-        <a
-          href="https://docs.credova.com"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Docs{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={2}
-                stroke="currentColor"
-                className="size-4"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25"
-                />
-              </svg>
-            </span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Find in-depth information about Credova features and SDK.
-          </p>
-        </a>
-      </div>
-    </main>
+        <div className="mb-32 flex justify-center text-center lg:mb-0 lg:w-full lg:max-w-5xl lg:text-left">
+          <a
+            href="https://docs.credova.com"
+            className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h2 className="mb-3 text-2xl font-semibold">
+              Docs{' '}
+              <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                  className="size-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25"
+                  />
+                </svg>
+              </span>
+            </h2>
+            <p className="m-0 max-w-[30ch] text-sm opacity-50">
+              Find in-depth information about Credova features and SDK.
+            </p>
+          </a>
+        </div>
+      </main>
+    </>
   )
 }

--- a/example-app/yarn.lock
+++ b/example-app/yarn.lock
@@ -27,13 +27,15 @@
     snake-case "^3.0.4"
     snakecase-keys "^3.2.1"
 
-"@credova/elements-js@file:../js-sdk":
-  version "0.0.0"
+"@credova/elements-js@^1.1.1", "@credova/elements-js@file:../js-sdk":
+  version "1.1.1"
   dependencies:
     "@basis-theory/basis-theory-js" "^4.6.2"
 
 "@credova/elements-react@file:../react-sdk":
-  version "0.0.0"
+  version "1.1.1"
+  dependencies:
+    "@credova/elements-js" "^1.1.1"
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -23,7 +23,7 @@
     "test:cov": "jest --coverage"
   },
   "dependencies": {
-    "@credova/elements-js": "^1.1.0"
+    "@credova/elements-js": "^1.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.15",

--- a/react-sdk/src/types/sdk.ts
+++ b/react-sdk/src/types/sdk.ts
@@ -1,1 +1,1 @@
-export * from '@credova/elements-js/dist/types/sdk'
+export * from '../../node_modules/@credova/elements-js/dist/types/sdk'

--- a/react-sdk/yarn.lock
+++ b/react-sdk/yarn.lock
@@ -1059,8 +1059,10 @@
     snake-case "^3.0.4"
     snakecase-keys "^3.2.1"
 
-"@credova/elements-js@file:../js-sdk":
-  version "0.0.0"
+"@credova/elements-js@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@credova/elements-js/-/elements-js-1.1.1.tgz#9d351d34b21397e0b7e5db47c08c4f4987923cd7"
+  integrity sha512-rFJUcICgxII1uls9iJHs/vVhmLbekriaa/+lZikPzi8ntnsTFdN42qGzIhYIDWiIwpRJmp4mOjXiHaUuwiMwJQ==
   dependencies:
     "@basis-theory/basis-theory-js" "^4.6.2"
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Fix type export issue from @credova/elements-js. Makes it so you can use elements-js types without installing the package if you've only installed @credova/elements-react.
- Bump version

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change